### PR TITLE
Propagate errors gracefully

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -174,7 +174,8 @@ async fn proxy<C: ProxyClient>(
             request = request.header("Proxy-Authorization", format!("Preshared {preshared_key}"));
         }
 
-        let request = request.body(http_body_util::Empty::new()).unwrap();
+        let request = request.body(http_body_util::Empty::new())
+            .map_err(|e| anyhow!("failed to create request: {e}"))?;
 
         tracing::debug!("sending CONNECT request");
 


### PR DESCRIPTION
Issue #6 notes a rogue user can panic chaussette tasks by passing an invalid domain. In this change we review the use of unwrap and expect, replacing them with graceful error propagation whenever the result may be dependant on proxy user input.

Closes #6